### PR TITLE
Omit empty status

### DIFF
--- a/apis/notification-ctrlr/v1alpha1/notification_types.go
+++ b/apis/notification-ctrlr/v1alpha1/notification_types.go
@@ -43,7 +43,7 @@ const (
 // NotificationStatus defines the observed state of Notification
 type NotificationStatus struct {
 	// State of syncing this object, when syncing is enabled
-	State NotificationState `json:"state"`
+	State NotificationState `json:"state,omitempty"`
 }
 
 //+kubebuilder:object:root=true
@@ -55,8 +55,8 @@ type Notification struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   NotificationSpec   `json:"spec,omitempty"`
-	Status NotificationStatus `json:"status,omitempty"`
+	Spec   NotificationSpec    `json:"spec,omitempty"`
+	Status *NotificationStatus `json:"status,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/config/crd/bases/notification-ctrlr.netop-types.io_notifications.yaml
+++ b/config/crd/bases/notification-ctrlr.netop-types.io_notifications.yaml
@@ -107,8 +107,6 @@ spec:
               state:
                 description: State of syncing this object, when syncing is enabled
                 type: string
-            required:
-            - state
             type: object
         type: object
     served: true


### PR DESCRIPTION
Missing omit empty on status causes it to show up
on argo git repo. Since argocd does not sync status, notification eventually shows up as not synced on
control cluster.

Signed-off-by: Kiran Shastri <shastrinator@gmail.com>